### PR TITLE
Updating the version number for WP 6.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change log
 
+# [[1.5.7]](https://github.com/lightspeeddevelopment/lsx-search/releases/tag/1.5.7) - 2023-08-09
+
+### Security
+- General testing to ensure compatibility with latest WordPress version (6.3).
+
 # [[1.5.6]](https://github.com/lightspeeddevelopment/lsx-search/releases/tag/1.5.6) - 2023-04-20
 
 ### Security

--- a/lsx-search.php
+++ b/lsx-search.php
@@ -4,7 +4,7 @@
  * Plugin URI:	https://github.com/lightspeeddevelopment/lsx-search
  * Description:	The LSX Search extension improves the search result pages for LSX Theme.
  * Author:		LightSpeed
- * Version: 	1.5.6
+ * Version: 	1.5.7
  * Author URI: 	https://www.lsdev.biz/
  * License: 	GPL3
  * Text Domain: lsx-search
@@ -19,7 +19,7 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'LSX_SEARCH_PATH', plugin_dir_path( __FILE__ ) );
 define( 'LSX_SEARCH_CORE', __FILE__ );
 define( 'LSX_SEARCH_URL', plugin_dir_url( __FILE__ ) );
-define( 'LSX_SEARCH_VER', '1.5.6' );
+define( 'LSX_SEARCH_VER', '1.5.7' );
 
 /* ======================= Below is the Plugin Class init ========================= */
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsx-search",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "LSX Search for LSX Theme.",
   "main": "gulpfile.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: feedmymedia, lightspeedwp, eleshar, krugazul, jacquesvdh, ignusver
 Donate link: https://lsdev.biz/lsx/donate/
 Tags: lsx, search, facetwp, Gutenberg, category
 Requires at least: 5.0
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 7.0
-Stable tag: 1.5.6
+Stable tag: 1.5.7
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 


### PR DESCRIPTION
### Description
- General testing to ensure compatibility with latest WordPress version (6.3).
- Updating the version number and stable tag